### PR TITLE
Support History on REPL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 rand = "0.8.5"
+rustyline = "12.0.0"
 
 [profile.release]
 opt-level = 3

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1,10 +1,12 @@
-use std::{io::{self, Write}, process::exit};
+use std::process::exit;
 
 use crate::{
     parser::Parser,
     preprocessor::Preprocessor,
     runtime::Runtime, common::errors::ErrorType
 };
+
+use rustyline::DefaultEditor;
 
 
 pub fn start_rpel(){
@@ -14,16 +16,23 @@ pub fn start_rpel(){
 
     let parser = Parser;
 
+    let mut reader = DefaultEditor::new().unwrap(); // TODO: handle error
+
     let mut runtime = Runtime::new(|msg|{
         println!("{}", msg);
     },||{
-        input()
+        String::from("")
     });
 
     loop {
-        print!("-> ");
-        let _ = io::stdout().flush();
-        let source = input(); 
+        // let source: String;
+        let source = match reader.readline("-> ") {
+            Ok(line) => {
+                let _ = reader.add_history_entry(line.clone());
+                line
+            },
+            Err(_) => break,
+        };
         let lines = preprocessor.on_new_line(source);
         for line in lines{
             let el = parser.on_new_line(line);
@@ -48,12 +57,4 @@ pub fn start_rpel(){
             }
         }
     }
-}
-
-fn input() -> String{
-        let mut buffer = String::new();
-        let stdin = io::stdin(); // We get `Stdin` here.
-        stdin.read_line(&mut buffer).unwrap();
-        buffer = buffer.replace("\n", "").trim().to_string();
-        buffer
 }


### PR DESCRIPTION
support hitory on REPL, so the user does not have to retype again and again the same things, but can use down/up arrows in order to search and re-edit already inserted lines of text.