### PR TITLE
feat(builtin): add `less_than_equal` (<=) built-in function (#11)

### DIFF
--- a/src/builtin_function/bools/less_than_equal.rs
+++ b/src/builtin_function/bools/less_than_equal.rs
@@ -1,0 +1,26 @@
+use crate::builtin_function::utils::{param_to_datatype, returns};
+use crate::common::data_type::DataType;
+use crate::common::errors::{ChapError, Result};
+use crate::{common::executable::ExecutableLine, runtime::Runtime};
+
+pub fn less_than_equal(runtime: &mut Runtime, executable: &ExecutableLine) -> Result<()> {
+    let p1 = param_to_datatype(runtime, executable.params.first(), executable.line_number)?;
+    let p2 = param_to_datatype(runtime, executable.params.get(1), executable.line_number)?;
+
+    let result = less_than_equal_data_types(p1, p2)?;
+
+    returns(runtime, executable, result)
+}
+
+pub fn less_than_equal_data_types(dt1: &DataType, dt2: &DataType) -> Result<DataType> {
+    match (dt1, dt2) {
+        (DataType::Int(x1), DataType::Int(x2)) => Ok(DataType::Bool(x1 <= x2)),
+        (DataType::Int(x1), DataType::Float(x2)) => Ok(DataType::Bool(f64::from(*x1) <= *x2)),
+        (DataType::Float(x1), DataType::Int(x2)) => Ok(DataType::Bool(*x1 <= f64::from(*x2))),
+        (DataType::Float(x1), DataType::Float(x2)) => Ok(DataType::Bool(x1 <= x2)),
+        _ => Err(ChapError::runtime_with_msg(
+            0,
+            "less_than_equal function works only with numbers int and float".to_string(),
+        )),
+    }
+}

--- a/src/builtin_function/mod.rs
+++ b/src/builtin_function/mod.rs
@@ -75,6 +75,7 @@ pub fn function_match(function_name: &str) -> Option<BuiltinFunction> {
         "not" => Some(bools::not::not),
         "gt" | "greaterthan" => Some(bools::greater_than::greater_than),
         "lt" | "lessthan" => Some(bools::less_than::less_than),
+        "lte" | "lessthanequal" => Some(bools::less_than_equal::less_than_equal),
         "concat" | "cat" => Some(strings::contact::concat),
         "repeat" => Some(strings::repeat::repeat),
         "length" | "len" => Some(strings::length::length),


### PR DESCRIPTION
This commit introduces the `less_than_equal` built-in function, which performs a less-than-or-equal-to (<=) comparison between two numeric values.

- Supports comparisons between Int and Float types
- Returns a `DataType::Bool` result
- Returns a runtime error for non-numeric types