### PR TITLE
fix: bools 'or' function logical issue

### DIFF
--- a/src/builtin_function/bools/or.rs
+++ b/src/builtin_function/bools/or.rs
@@ -4,7 +4,7 @@ use crate::common::errors::{ChapError, Result};
 use crate::{common::executable::ExecutableLine, runtime::Runtime};
 
 pub fn or(runtime: &mut Runtime, executable: &ExecutableLine) -> Result<()> {
-    let mut result = true;
+    let mut result = false;
     for param in &executable.params {
         let dt = param_to_datatype(runtime, Some(param), executable.line_number)?;
         match dt {


### PR DESCRIPTION
## Description
The `or` function initialized the result to true, causing the following behavior:

## Behavior Before (dev/stable branch)

```
-> true, true -> or
true
-> false, true -> or
true
-> false, false -> or
true (invalid)
```

## Behavior After (fix branch)
```
-> true, true -> or
true
-> false, true -> or
true
-> false, false -> or
false
```